### PR TITLE
feat: JWT 토큰 비지니스 로직 및 Interceptor&WebConfig 추가

### DIFF
--- a/src/main/java/com/pprisam/backend/config/web/WebConfig.java
+++ b/src/main/java/com/pprisam/backend/config/web/WebConfig.java
@@ -1,0 +1,46 @@
+package com.pprisam.backend.config.web;
+
+import com.pprisam.backend.interceptor.AuthorizationInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthorizationInterceptor authorizationInterceptor;
+
+    //회원가입, 로그인 등 비로그인한 상태
+    private List<String> OPEN_API = List.of(
+            "/open-api/**"
+    );
+
+    //기본 제외 주소
+    private List<String> DEFAULT_EXCLUDE = List.of(
+            "/", //루트 주소
+            "favicon.ico", //아이콘 요청 주소
+            "/error" // 에러 처리 주소
+    );
+
+    //Swagger 관련 주소
+    private List<String> SWAGGER = List.of(
+            "/swagger-ui.html",
+            "/swagger-ui/**",
+            "/v3/api-docs/**"
+    );
+
+    // 인터셉터 등록
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authorizationInterceptor)
+                // Interceptor의 인증을 제외시킴
+                .excludePathPatterns(OPEN_API)
+                .excludePathPatterns(DEFAULT_EXCLUDE)
+                .excludePathPatterns(SWAGGER)
+        ;
+    }
+}

--- a/src/main/java/com/pprisam/backend/domain/token/business/TokenBusiness.java
+++ b/src/main/java/com/pprisam/backend/domain/token/business/TokenBusiness.java
@@ -1,0 +1,43 @@
+package com.pprisam.backend.domain.token.business;
+
+import com.pprisam.backend.domain.token.converter.TokenConverter;
+import com.pprisam.backend.domain.token.model.TokenResponse;
+import com.pprisam.backend.domain.token.service.TokenService;
+import com.pprisam.backend.domain.user.repository.UserEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class TokenBusiness {
+
+    private final TokenService tokenService;
+    private final TokenConverter tokenConverter;
+
+    // User 로그인 시, 토큰 발급 용도로 이용할 예정
+    public TokenResponse issueToken(UserEntity userEntity) {
+        return Optional.ofNullable(userEntity)
+                // User Entity에서 User Id 추출
+                .map(ue -> {
+                    return ue.getId();
+                })
+
+                // User Id를 통해 JWT Access/Refresh Token 발급 + Converter를 사용하여 변환
+                .map(userId -> {
+                    var accessToken = tokenService.issueAccessToken(userId);
+                    var refreshToken = tokenService.issueRefreshToken(userId);
+                    return tokenConverter.toResponse(accessToken, refreshToken);
+                })
+
+                .orElseThrow(() -> new RuntimeException("Null"));
+    }
+
+    // 토큰 검증하여 User Id 반환
+    public Long validationAccessToken(String accessToken) {
+        var userId = tokenService.validationToken(accessToken);
+        return userId;
+    }
+
+}

--- a/src/main/java/com/pprisam/backend/interceptor/AuthorizationInterceptor.java
+++ b/src/main/java/com/pprisam/backend/interceptor/AuthorizationInterceptor.java
@@ -1,0 +1,65 @@
+package com.pprisam.backend.interceptor;
+
+import com.pprisam.backend.domain.token.business.TokenBusiness;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.resource.ResourceHttpRequestHandler;
+
+import java.util.Objects;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class AuthorizationInterceptor implements HandlerInterceptor {
+
+    private final TokenBusiness tokenBusiness;
+
+    // Controller 실행 전에 검증을 담당하는 메소드
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        // 요청 URL 출력
+        log.info("Authorization Interceptor url : {}", request.getRequestURI());
+
+        // OPTIONS 메소드는 CORS 프리플라이트 요청으로 통과
+        // 프리플라이트 요청 : CORS 문제 방지를 위해 요청이 가능한지를 미리 확인하는 요청
+        if(HttpMethod.OPTIONS.matches(request.getMethod())) {
+            return true;
+        }
+
+        // 정적 리소스(js, html, png 등)에 대한 요청은 통과
+        if(handler instanceof ResourceHttpRequestHandler) {
+            return true;
+        }
+
+        // Request-Header에서 JWT 토큰을 추출
+        var accessToken = request.getHeader("authorization-token");
+
+        // Token이 없을 경우 오류 처리
+        if(accessToken == null) {
+            throw new RuntimeException("Access Token Null");
+        }
+
+        // 토큰 검증 후, User Id 반환
+        var userId = tokenBusiness.validationAccessToken(accessToken);
+
+        // User Id가 있으면, RequestContext에 User Id 저장
+        // RequestContext : 요청에 대한 정보를 저장하고 관리하는 컨테이너 역할
+        if(userId != null) {
+            var requestContext = Objects.requireNonNull(RequestContextHolder.getRequestAttributes());
+            // SCOPE_REQUEST에 의해 해당 요청이 끝날 때까지  userId 속성 유지
+            requestContext.setAttribute("userId", userId, RequestAttributes.SCOPE_REQUEST);
+            return true;
+        }
+
+        // Token 검증 실패
+        throw new RuntimeException("인증 실패");
+    }
+}
+


### PR DESCRIPTION
## Summary
JWT 토큰 비지니스 로직 및 사용자의 요청으로부터 토큰을 검증하는 인터셉터와 인증 제외 URL 설정 

## Description
- TokenBusiness 클래스 작성
- AuthorizationInterceptor 클래스 생성
- WebConfig 클래스 생성

## Test Checklist
- [ ] TokenBusiness와 TokenService의 관계
- [ ] AuthorizationInterceptor의 역할
- [ ] 참고하면 좋은 개념  ex) OPTIONS 메소드-CORS 프리플라이트 요청, RequestContext 
