### PR TITLE
feat: Contact 저장 api

### DIFF
--- a/src/main/java/com/pprisam/backend/domain/contact/controller/ContactController.java
+++ b/src/main/java/com/pprisam/backend/domain/contact/controller/ContactController.java
@@ -1,0 +1,34 @@
+package com.pprisam.backend.domain.contact.controller;
+
+import com.pprisam.backend.config.annotation.UserSession;
+import com.pprisam.backend.domain.contact.model.ContactDTO;
+import com.pprisam.backend.domain.contact.repository.ContactRepository;
+import com.pprisam.backend.domain.contact.repository.entity.ContactEntity;
+import com.pprisam.backend.domain.contact.service.ContactService;
+import com.pprisam.backend.domain.user.model.User;
+import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/open-api/contacts")   // jwt 관련 설정 세팅전 임시 endpoint 설정
+public class ContactController {
+    @Autowired
+    private ContactService contactService;
+
+    @PostMapping("")
+    public ResponseEntity<ContactEntity> createContact(
+            @RequestBody ContactDTO contactDTO
+//            @Parameter(hidden = true)
+//            @UserSession User user
+    ) {
+
+        ContactEntity savedContact = contactService.save(contactDTO);
+        return ResponseEntity.ok(savedContact);
+
+    }
+}

--- a/src/main/java/com/pprisam/backend/domain/contact/model/ContactDTO.java
+++ b/src/main/java/com/pprisam/backend/domain/contact/model/ContactDTO.java
@@ -1,0 +1,18 @@
+package com.pprisam.backend.domain.contact.model;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+
+@Data
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ContactDTO {
+
+    private String name;
+
+    private String phoneNumber;
+
+    private String memo;
+
+}

--- a/src/main/java/com/pprisam/backend/domain/contact/repository/ContactRepository.java
+++ b/src/main/java/com/pprisam/backend/domain/contact/repository/ContactRepository.java
@@ -1,5 +1,6 @@
 package com.pprisam.backend.domain.contact.repository;
 
+import com.pprisam.backend.domain.contact.repository.entity.ContactEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ContactRepository extends JpaRepository<ContactEntity, Long> {

--- a/src/main/java/com/pprisam/backend/domain/contact/repository/GroupMemberRepository.java
+++ b/src/main/java/com/pprisam/backend/domain/contact/repository/GroupMemberRepository.java
@@ -1,5 +1,6 @@
 package com.pprisam.backend.domain.contact.repository;
 
+import com.pprisam.backend.domain.contact.repository.entity.GroupMemberEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GroupMemberRepository extends JpaRepository<GroupMemberEntity, Long> {

--- a/src/main/java/com/pprisam/backend/domain/contact/repository/GroupRepository.java
+++ b/src/main/java/com/pprisam/backend/domain/contact/repository/GroupRepository.java
@@ -1,5 +1,6 @@
 package com.pprisam.backend.domain.contact.repository;
 
+import com.pprisam.backend.domain.contact.repository.entity.GroupEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GroupRepository extends JpaRepository<GroupEntity, Long> {

--- a/src/main/java/com/pprisam/backend/domain/contact/repository/entity/ContactEntity.java
+++ b/src/main/java/com/pprisam/backend/domain/contact/repository/entity/ContactEntity.java
@@ -1,5 +1,6 @@
-package com.pprisam.backend.domain.contact.repository;
+package com.pprisam.backend.domain.contact.repository.entity;
 
+import com.pprisam.backend.domain.user.repository.UserEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -11,17 +12,25 @@ import org.hibernate.annotations.UpdateTimestamp;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "contact_group")  // group이 예약어로 테이블명 생성 불가하여 대체
+@Table(name = "contact")
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class GroupEntity {
+public class ContactEntity {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY) // id 기본키로 자동 생성
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private UserEntity userEntity;
+
     private String name;
+
+    private String phoneNumber;
+
+    private String memo;
 
     @CreationTimestamp // 레코드가 생성될 때 자동으로 해당 필드에 현재 날짜와 시간을 기록
     private LocalDateTime createdAt;

--- a/src/main/java/com/pprisam/backend/domain/contact/repository/entity/GroupEntity.java
+++ b/src/main/java/com/pprisam/backend/domain/contact/repository/entity/GroupEntity.java
@@ -1,6 +1,5 @@
-package com.pprisam.backend.domain.contact.repository;
+package com.pprisam.backend.domain.contact.repository.entity;
 
-import com.pprisam.backend.domain.user.repository.UserEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,25 +11,17 @@ import org.hibernate.annotations.UpdateTimestamp;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "contact")
+@Table(name = "contact_group")  // group이 예약어로 테이블명 생성 불가하여 대체
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ContactEntity {
+public class GroupEntity {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.IDENTITY) // id 기본키로 자동 생성
     private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = "user_id")
-    private UserEntity userEntity;
-
     private String name;
-
-    private String phoneNumber;
-
-    private String memo;
 
     @CreationTimestamp // 레코드가 생성될 때 자동으로 해당 필드에 현재 날짜와 시간을 기록
     private LocalDateTime createdAt;

--- a/src/main/java/com/pprisam/backend/domain/contact/repository/entity/GroupMemberEntity.java
+++ b/src/main/java/com/pprisam/backend/domain/contact/repository/entity/GroupMemberEntity.java
@@ -1,4 +1,4 @@
-package com.pprisam.backend.domain.contact.repository;
+package com.pprisam.backend.domain.contact.repository.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/pprisam/backend/domain/contact/service/ContactService.java
+++ b/src/main/java/com/pprisam/backend/domain/contact/service/ContactService.java
@@ -1,0 +1,27 @@
+package com.pprisam.backend.domain.contact.service;
+
+import com.pprisam.backend.domain.contact.model.ContactDTO;
+import com.pprisam.backend.domain.contact.repository.ContactRepository;
+import com.pprisam.backend.domain.contact.repository.entity.ContactEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ContactService {
+    @Autowired
+    private ContactRepository contactRepository;
+
+    // DTO에서 데이터 출력
+    public ContactEntity save(ContactDTO contactDTO) {
+        ContactEntity contactEntity = ContactEntity.builder()
+                .name(contactDTO.getName())
+                .phoneNumber(contactDTO.getPhoneNumber())
+                .memo(contactDTO.getMemo())
+                .build();
+
+        // Repository를 통해 DB에 저장
+        return contactRepository.save(contactEntity);
+    }
+}


### PR DESCRIPTION
## Summary
Contact 저장 api 추가

## Description
- ContactController에서 api endpoint 추가
- ContactDTO에 입력데이터 설정
- ContactService에서 로직 구현

## Test Checklist
- [ ] /open-api/contacts에서 저장할 연락처 입력 후 db 저장 확인

