### PR TITLE
[setting] elasticsearch 초기세팅 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,10 @@ dependencies {
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.12.5'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.12.5'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.12.5'
+
+	//Elasticsearch
+	implementation'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+	implementation 'co.elastic.clients:elasticsearch-java:8.13.4'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,5 +37,22 @@ services:
       timeout: 5s
       retries: 5
 
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+    container_name: elasticsearch
+    environment:
+      - node.name=elasticsearch-node
+      - cluster.name=search-cluster
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - xpack.security.http.ssl.enabled=false
+      - xpack.security.transport.ssl.enabled=false
+    ports:
+      - "9200:9200" # http
+      - "9300:9300" # tcp
+    networks:
+      - ppurisam_network
+
+
 networks:
   ppurisam_network:


### PR DESCRIPTION
## Summary
elasticsearch 초기세팅 구현

## Description
application.properties 수정사항
- spring.profiles.active=dev // 프로파일 설정 코드
 -spring.elasticsearch.uris=http://es:9200 // Elasticsearch 서버 URI 설정하는 코드

docker-compose.yml 파일에 elasticsearch 코드 추가했음. (커밋 코드 확인바람)

build.greade에 의존성 추가함.
- implementation'org.springframework.boot:spring-boot-starter-data-elasticsearch'
- implementation 'co.elastic.clients:elasticsearch-java:8.13.4' // 스프링 버전에 맞게 설정

## Test Checklist
- [ ] pull 받고 docker 잘 작동하는지 확인하기

