### PR TITLE
feat:  elasticsearch 연락처 검색 기능 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,16 +46,23 @@ services:
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+    volumes:
+      - es_data:/usr/share/elasticsearch/data
     container_name: elasticsearch
     environment:
       - node.name=elasticsearch-node
       - cluster.name=search-cluster
       - discovery.type=single-node
-      - xpack.security.enabled=true
-      - xpack.security.http.ssl.enabled=false
+      - xpack.security.enabled=false
       - xpack.security.transport.ssl.enabled=false
+      - xpack.security.http.ssl.enabled=false
       - ELASTIC_PASSWORD=1234
       - ES_JAVA_OPTS=-Xms1g -Xmx1g
+    command: >
+      sh -c "
+        elasticsearch-plugin remove analysis-nori || true &&
+        elasticsearch-plugin install analysis-nori &&
+        elasticsearch"
     ports:
       - "9200:9200" # HTTP
       - "9300:9300" # TCP
@@ -70,3 +77,6 @@ services:
 
 networks:
   ppurisam_network:
+
+volumes:
+  es_data:

--- a/src/main/java/com/pprisam/backend/domain/contact/controller/ContactController.java
+++ b/src/main/java/com/pprisam/backend/domain/contact/controller/ContactController.java
@@ -4,6 +4,7 @@ import com.pprisam.backend.config.annotation.UserSession;
 import com.pprisam.backend.domain.contact.model.ContactRequest;
 import com.pprisam.backend.domain.contact.model.ContactResponse;
 import com.pprisam.backend.domain.contact.repository.document.ContactDocument;
+import com.pprisam.backend.domain.contact.service.ContactSearchService;
 import com.pprisam.backend.domain.contact.service.ContactService;
 import com.pprisam.backend.domain.user.model.User;
 import com.pprisam.backend.domain.user.model.UserIdResponse;
@@ -14,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Collections;
 import java.util.List;
 
 @RestController
@@ -21,6 +23,9 @@ import java.util.List;
 public class ContactController {
     @Autowired
     private ContactService contactService;
+
+    @Autowired
+    private ContactSearchService contactSearchService;
 
     @PostMapping("")
     public ResponseEntity<ContactResponse> createContact(
@@ -59,7 +64,6 @@ public class ContactController {
         return ResponseEntity.noContent().build(); // 204 No Content 반환
     }
 
-
     @GetMapping("")
     public ResponseEntity<List<ContactResponse>> getAllContacts(){
         List<ContactResponse> contacts = contactService.findAll(); // 전체 연락처 조회
@@ -69,5 +73,17 @@ public class ContactController {
     @GetMapping("/{id}")
     public ResponseEntity<ContactResponse> getContactById(@PathVariable Long id){
         return ResponseEntity.ok(contactService.findById(id));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<List<ContactDocument>> searchContactsByNameOrPhoneNumber(@RequestParam String keyword) {
+        try {
+            List<ContactDocument> results = contactSearchService.searchContacts(keyword);
+            return ResponseEntity.ok(results);
+        } catch (Exception e) {
+            // 여기서 구체적인 에러 로그를 추가
+            e.printStackTrace();
+            return ResponseEntity.status(500).body(Collections.emptyList());
+        }
     }
 }

--- a/src/main/java/com/pprisam/backend/domain/contact/repository/ContactDocumentRepository.java
+++ b/src/main/java/com/pprisam/backend/domain/contact/repository/ContactDocumentRepository.java
@@ -16,4 +16,6 @@ public interface ContactDocumentRepository extends ElasticsearchRepository<Conta
     // 그룹 이름으로 검색하는 메서드 예시
     List<ContactDocument> findByGroupsNameContaining(String groupName);
     void deleteByContactId(Long userId);
+
+    List<ContactDocument> findByNameContainingOrPhoneNumberContaining(String name, String phoneNumber);
 }

--- a/src/main/java/com/pprisam/backend/domain/contact/repository/document/ContactDocument.java
+++ b/src/main/java/com/pprisam/backend/domain/contact/repository/document/ContactDocument.java
@@ -1,14 +1,18 @@
 package com.pprisam.backend.domain.contact.repository.document;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.annotation.Id;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 @Data
@@ -16,34 +20,45 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Document(indexName = "contacts")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ContactDocument {
 
-    @org.springframework.data.annotation.Id
+    @Id
     private Long id;
 
+    @Field(type = FieldType.Long)
     private Long userId;
 
+    @Field(type = FieldType.Long)
     private Long contactId;
 
+    @Field(type = FieldType.Text, analyzer = "nori")
     private String name;
 
+    @Field(type = FieldType.Text)
     private String phoneNumber;
 
+    @Field(type = FieldType.Text)
     private String memo;
 
     @Field(type = FieldType.Nested, includeInParent = true)
     private List<GroupInfo> groups;
 
-    private LocalDateTime createdAt;
+    @Field(type = FieldType.Date, format = DateFormat.date_time)
+    private OffsetDateTime createdAt;
 
-    private LocalDateTime updatedAt;
+    @Field(type = FieldType.Date, format = DateFormat.date_time)
+    private OffsetDateTime updatedAt;
 
     @Data
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     public static class GroupInfo {
+        @Field(type = FieldType.Long)
         private Long id;
+
+        @Field(type = FieldType.Text)
         private String name;
     }
 }

--- a/src/main/java/com/pprisam/backend/domain/contact/repository/entity/ContactEntity.java
+++ b/src/main/java/com/pprisam/backend/domain/contact/repository/entity/ContactEntity.java
@@ -11,6 +11,7 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 @Entity
@@ -38,19 +39,19 @@ public class ContactEntity {
     private List<GroupMemberEntity> groupMembers;
 
     @CreationTimestamp // 레코드가 생성될 때 자동으로 해당 필드에 현재 날짜와 시간을 기록
-    private LocalDateTime createdAt;
+    private OffsetDateTime createdAt;
 
     @UpdateTimestamp // 레코드가 수정될 때 자동으로 해당 필드에 현재 날짜와 시간을 기록
-    private LocalDateTime updatedAt;
+    private OffsetDateTime updatedAt;
 
     @PrePersist
     public void prePersist() {
-        createdAt = LocalDateTime.now();
+        createdAt = OffsetDateTime.now();
         updatedAt = createdAt;
     }
 
     @PreUpdate
     public void preUpdate() {
-        updatedAt = LocalDateTime.now();
+        updatedAt = OffsetDateTime.now();
     }
 }

--- a/src/main/java/com/pprisam/backend/domain/contact/service/ContactSearchService.java
+++ b/src/main/java/com/pprisam/backend/domain/contact/service/ContactSearchService.java
@@ -1,0 +1,18 @@
+package com.pprisam.backend.domain.contact.service;
+
+import com.pprisam.backend.domain.contact.repository.ContactDocumentRepository;
+import com.pprisam.backend.domain.contact.repository.document.ContactDocument;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ContactSearchService {
+
+    private final ContactDocumentRepository contactDocumentRepository;
+
+    public List<ContactDocument> searchContacts(String nameOrPhoneNumber) {
+        return contactDocumentRepository.findByNameContainingOrPhoneNumberContaining(nameOrPhoneNumber, nameOrPhoneNumber);
+    }
+}


### PR DESCRIPTION
## Summary
elasticsearch 연락처 검색 기능 추가

## Description
- **ContactSearchService.java:**  elasticsearch 검색 서비스 로직 구현 코드
- ** docker-compose.ym:l** nori(ngram analyzer) 빌드 다운 or 도커 꺼져도 볼륨에 해당 인덱스 남게 수정
- **ContactController.java:** search controller 추가 코드
- **ContactDocumentRepository.java:** 이름 + 전화번호 키워드 묶는 코드 추가
- **ContactDocument.java:** createdAt, updatedAt -> OffsettDateTime으로 변경 => 인덱싱 과정에서 시간차이가 있어서 오류 발생시킴. 이를, OffsettDateTime을 사용함으로써 시간 일괄 통합 시킴
- **ContactEntity:** 위와 동일

<img width="1066" alt="image" src="https://github.com/user-attachments/assets/1fa62f64-3225-4eb1-81e5-fa2bd3760eb8">
<img width="1063" alt="image" src="https://github.com/user-attachments/assets/bc8e932c-b3bc-4c9e-ab18-f23780fda53e">

## Test Checklist
- [ ] 인덱싱하고 검색 해보기.

